### PR TITLE
Add GitHub Copilot certification to profile README

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -26,6 +26,11 @@ I enjoy helping others understand and leverage Microsoft's service offerings to 
 - **Certifications:**
   - Microsoft Certified: Azure Virtual Desktop Specialty (AZ-140)
   - Microsoft Certified: Power Platform Fundamentals (PL-900)
+  - [GitHub Copilot Certification Program (GH-300)](https://learn.microsoft.com/api/credentials/share/en-us/takescake/DFCC6C77050E272F?sharingId=E52D3E764CCA814C)
+
+<p align="center">
+  <img src="https://learn.microsoft.com/api/credentials/share/en-us/takescake/DFCC6C77050E272F/image" alt="GitHub Copilot Certification Badge" width="200" />
+</p>
 
 ## 🧰 Projects & Contributions
 


### PR DESCRIPTION
## Summary
- add newly earned GitHub Copilot certification to the profile README
- embed the official certification badge image for visual confirmation

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68e58fc2d2ec83308c33ce92eb9fbd0f